### PR TITLE
Tweak Marconi plots

### DIFF
--- a/00_basic_scaling/marconi-gcc-openmpi/plot_scaling.py
+++ b/00_basic_scaling/marconi-gcc-openmpi/plot_scaling.py
@@ -49,10 +49,10 @@ def plot_strong_scaling(nprocs, times, fname="strong_scaling.png"):
     plt.minorticks_off()
     ax.set_xticks(nprocs)
     ax.set_xticklabels(nprocs)
-    tvec = [70, 100, 200, 300, 400, 500, 600, 700, 1000, 1400, 1800]
+    tvec = [100, 200, 350, 600, 1200, 2500, 5000]
     ax.set_yticks(tvec)
     ax.set_yticklabels(tvec)
-    plt.ylim(70, 1800)
+    plt.ylim(50, 6000)
     plt.grid()
     plt.xlabel("MPI ranks")
     plt.ylabel("Run time / secs")


### PR DESCRIPTION
Tweak ylims and grid lines so data fits in image.

I haven't added the Marconi data to the joint plot of intel vs gcc on DINE. (I don't know if the runs have the same parameters / whether it's a fair comparison to make even if they do have the same parameters.)